### PR TITLE
added variables to customize fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ override.tf.json
 /*/node_modules
 
 /package-lock.json
+terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ A lab testing terraform on aws with sqs, comprehend and lambda
 
 ## Usage
 
+Create a file named `terraform.tfvars` and define variables named in `variables.tf`. For e.g:
+`s3_bucket_name = "desired_bucket_name"`
+
+
 ```
 $ terraform init
 $ terraform plan

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "terraform-aws-sqs-comprehend-lambda-s3-bucket" {
-  bucket = "terraform-aws-sqs-comprehend-lambda-s3-bucket-palerique"
+  bucket = var.s3_bucket_name
   acl = "private"
   tags = {
     Name = "terraform-aws-s3-bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,8 @@
+variable "region" {
+    type = string
+    default = "us-east-1"
+}
+
+variable "s3_bucket_name" {
+    type = string
+}


### PR DESCRIPTION
Variables like bucket name has been "parameterized" and whoever runs `terraform apply` should be required to provide a bucket name on the command line interface (or by `terraform.tfvars` file)  . This removes hardcoded bucket name and saves the developer time spent waiting for `terraform apply` to run only to be told later that a bucket of that name already exists.